### PR TITLE
Update build.gradle to use parser 1.5.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ repositories {
     mavenCentral()
     mavenLocal()
     maven { url = 'http://maptool.craigs-stuff.net/repo/' }
+    maven { url = 'https://jitpack.io' }
 }
 
 
@@ -38,7 +39,8 @@ repositories {
 dependencies {
     compile 'rhino:js:1.6R5'
     compile 'antlr:antlr:2.7.6'
-    compile 'net.rptools.parser:parser:1.1.b24'
+//    compile 'net.rptools.parser:parser:1.1.b24'
+    implementation 'com.github.RPTools:parser:1.5.5'
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }
 


### PR DESCRIPTION
Add jitpack.io to repos.  Callout parser 1.5.5 in dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/dicelib/8)
<!-- Reviewable:end -->
