### PR TITLE
Adding new dice expressions for RerollDiceOnce

### DIFF
--- a/src/main/java/net/rptools/common/expression/ExpressionParser.java
+++ b/src/main/java/net/rptools/common/expression/ExpressionParser.java
@@ -57,6 +57,14 @@ public class ExpressionParser {
         new String[] {"\\b(\\d+)[dD](\\d+)[rR](\\d+)\\b", "reroll($1, $2, $3)"},
         new String[] {"\\b[dD](\\d+)[rR](\\d+)\\b", "reroll(1, $1, $2)"},
 
+        // re-roll once and keep the new value
+        new String[] {"\\b(\\d+)[dD](\\d+)[rR][kK](\\d+)\\b", "rerollOnce($1, $2, $3)"},
+        new String[] {"\\b[dD](\\d+)[rR][kK](\\d+)\\b", "rerollOnce(1, $1, $2)"},
+
+        // re-roll once and choose the higher value
+        new String[] {"\\b(\\d+)[dD](\\d+)[rR][cC](\\d+)\\b", "rerollOnce($1, $2, $3, true)"},
+        new String[] {"\\b[dD](\\d+)[rR][cC](\\d+)\\b", "rerollOnce(1, $1, $2, true)"},
+
         // count success
         new String[] {"\\b(\\d+)[dD](\\d+)[sS](\\d+)\\b", "success($1, $2, $3)"},
         new String[] {"\\b[dD](\\d+)[sS](\\d+)\\b", "success(1, $1, $2)"},
@@ -177,6 +185,7 @@ public class ExpressionParser {
     parser.addFunction(new ExplodeDice());
     parser.addFunction(new KeepRoll());
     parser.addFunction(new RerollDice());
+    parser.addFunction(new RerollDiceOnce());
     parser.addFunction(new HeroRoll());
     parser.addFunction(new HeroKillingRoll());
     parser.addFunction(new FudgeRoll());

--- a/src/main/java/net/rptools/common/expression/function/DiceHelper.java
+++ b/src/main/java/net/rptools/common/expression/function/DiceHelper.java
@@ -117,7 +117,7 @@ public class DiceHelper {
 
     if (lowerBound > sides)
       throw new EvaluationException(
-          "When rerolling, the lowerbound must be smaller than the number of sides on the rolling dice.");
+              "When rerolling, the lowerbound must be smaller than the number of sides on the rolling dice.");
 
     int[] values = new int[times];
 
@@ -125,6 +125,48 @@ public class DiceHelper {
       int roll;
       while ((roll = runData.randomInt(sides)) < lowerBound) ;
 
+      values[i] = roll;
+    }
+
+    int result = 0;
+    for (int i = 0; i < values.length; i++) {
+      result += values[i];
+    }
+
+    return result;
+  }
+
+  /**
+   * Rolls X dice with Y sides each, with any result lower than L being re-rolled once.  If chooseHigher is true, the higher of the two rolled values is kept.  Otherwise, the new roll is kept regardless.
+   * <p>
+   * Differs from {@link #rerollDice(int, int, int)} in that the new results are allowed to fall beneath the given lowerBound, instead of being re-rolled again.
+   *
+   * @param times        the number of dice
+   * @param sides        the number of sides
+   * @param lowerBound   the number below which dice will be re-rolled. Must be strictly lower than the number of sides.
+   * @param chooseHigher whether the original result may be preserved if it was the higher value
+   * @return the total of the rolled and re-rolled dice
+   * @throws EvaluationException if an invalid lowerBound is provided
+   */
+  public static int rerollDiceOnce(int times, int sides, int lowerBound, boolean chooseHigher) throws EvaluationException {
+    RunData runData = RunData.getCurrent();
+
+    if (lowerBound > sides)
+      throw new EvaluationException(
+              "When rerolling, the lowerbound must be smaller than the number of sides on the rolling dice.");
+
+    int[] values = new int[times];
+
+    for (int i = 0; i < values.length; i++) {
+      int roll = runData.randomInt(sides);
+      if (roll < lowerBound) {
+        int roll2 = runData.randomInt(sides);
+        if (chooseHigher) {
+          roll = Math.max(roll, roll2);
+        } else {
+          roll = roll2;
+        }
+      }
       values[i] = roll;
     }
 

--- a/src/main/java/net/rptools/common/expression/function/RerollDiceOnce.java
+++ b/src/main/java/net/rptools/common/expression/function/RerollDiceOnce.java
@@ -1,0 +1,49 @@
+/*
+ * This software Copyright by the RPTools.net development team, and
+ * licensed under the Affero GPL Version 3 or, at your option, any later
+ * version.
+ *
+ * MapTool Source Code is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License * along with this source Code.  If not, please visit
+ * <http://www.gnu.org/licenses/> and specifically the Affero license
+ * text at <http://www.gnu.org/licenses/agpl.html>.
+ */
+package net.rptools.common.expression.function;
+
+import net.rptools.parser.Parser;
+import net.rptools.parser.function.AbstractNumberFunction;
+import net.rptools.parser.function.EvaluationException;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Will re-roll dice under a given threshold once, and optionally choose the higher of the two results.
+ * <p>
+ * Differs from {@link RerollDice} in that the new results are allowed to be below the lowerBound.
+ */
+public class RerollDiceOnce extends AbstractNumberFunction {
+
+  public RerollDiceOnce() {
+    super(3, 4, false, "rerollOnce");
+  }
+
+  @Override
+  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+          throws EvaluationException {
+    int n = 0;
+    int times = ((BigDecimal) parameters.get(n++)).intValue();
+    int sides = ((BigDecimal) parameters.get(n++)).intValue();
+    int lowerBound = ((BigDecimal) parameters.get(n++)).intValue();
+    boolean chooseHigher = false;
+    if (parameters.size() > n)
+      chooseHigher = !BigDecimal.ZERO.equals(parameters.get(n)); // as with If, anything other than 0 is truthy
+
+    return new BigDecimal(DiceHelper.rerollDiceOnce(times, sides, lowerBound, chooseHigher));
+  }
+
+}

--- a/src/test/java/net/rptools/common/expression/ExpressionParserTest.java
+++ b/src/test/java/net/rptools/common/expression/ExpressionParserTest.java
@@ -19,7 +19,6 @@ import java.math.BigInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import junit.framework.TestCase;
-import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 
 public class ExpressionParserTest extends TestCase {

--- a/src/test/java/net/rptools/common/expression/ExpressionParserTest.java
+++ b/src/test/java/net/rptools/common/expression/ExpressionParserTest.java
@@ -19,6 +19,7 @@ import java.math.BigInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import junit.framework.TestCase;
+import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 
 public class ExpressionParserTest extends TestCase {
@@ -51,6 +52,20 @@ public class ExpressionParserTest extends TestCase {
     Result result = new ExpressionParser().evaluate("100+10d6k8+1");
 
     assertEquals(new BigDecimal(138), result.getValue());
+  }
+
+  public void testEvaluate_RerollOnceAndKeep() throws ParserException {
+    RunData.setSeed(10423L);
+    Result result = new ExpressionParser().evaluate("20d10rk5");
+    // the sequence of rolls produced includes an instance of a 4 being replaced by a 3
+    assertEquals(new BigDecimal(121), result.getValue());
+  }
+
+  public void testEvaluate_RerollOnceAndChoose() throws ParserException {
+    RunData.setSeed(10423L);
+    Result result = new ExpressionParser().evaluate("20d10rc5");
+    // in rerollAndChoose mode, the 4 gets preserved instead of being replaced by the 3
+    assertEquals(new BigDecimal(122), result.getValue());
   }
 
   public void testEvaluate_CountSuccess() throws ParserException {


### PR DESCRIPTION
- Adds a new function RerollDiceOnce, like RerollDice but does not reroll repeatedly.  Optionally chooses the higher of the results, otherwise keeps the new roll regardless.
- Adds reroll-and-keep syntax like `2d6rk3` (will reroll any die less than 3, keeping the new result)
- Adds reroll-and-choose syntax like `2d6rc3` (will reroll any die less than 3, choosing the higher value)
- Adds tests for these new expressions

Fixes #27 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/dicelib/26)
<!-- Reviewable:end -->
