### PR TITLE
Providing a RunDataMockForTesting to produce a pre-configured sequence of "rolls" for testing

### DIFF
--- a/src/main/java/net/rptools/common/expression/ExpressionParser.java
+++ b/src/main/java/net/rptools/common/expression/ExpressionParser.java
@@ -207,8 +207,11 @@ public class ExpressionParser {
     Result ret = new Result(expression);
     RunData oldData = RunData.hasCurrent() ? RunData.getCurrent() : null;
     try {
-      RunData newRunData = new RunData(ret);
-      RunData.setCurrent(newRunData);
+      RunData newRunData = oldData;
+      if (oldData == null) {
+        newRunData = new RunData(ret);
+        RunData.setCurrent(newRunData);
+      }
 
       synchronized (parser) {
         Expression xp = parser.parseExpression(expression);

--- a/src/main/java/net/rptools/common/expression/RunData.java
+++ b/src/main/java/net/rptools/common/expression/RunData.java
@@ -30,7 +30,7 @@ public class RunData {
   private long randomMax;
   private long randomMin;
 
-  private List<Integer> rolled = new LinkedList<>();
+  protected List<Integer> rolled = new LinkedList<>();
 
   public RunData(Result result) {
     this.result = result;

--- a/src/test/java/net/rptools/common/expression/ExpressionParserWithMockRollsTest.java
+++ b/src/test/java/net/rptools/common/expression/ExpressionParserWithMockRollsTest.java
@@ -1,0 +1,84 @@
+package net.rptools.common.expression;
+
+import junit.framework.TestCase;
+import net.rptools.parser.ParserException;
+
+import java.math.BigDecimal;
+
+/**
+ * An alternative test suite that evaluates dice expressions against specific known roll sequences.  Uses {@link RunDataMockForTesting}.
+ */
+public class ExpressionParserWithMockRollsTest extends TestCase {
+    /**
+     * Helper method to initialize the RunData with the given rolls
+     *
+     * @param rolls the sequence of rolls that should be used
+     */
+    private void setUpMockRunData(int[] rolls) {
+        RunDataMockForTesting mockRD = new RunDataMockForTesting(new Result(""), rolls);
+        RunData.setCurrent(mockRD);
+    }
+
+    public void testEvaluate_ExplodeWithMockRunData() throws ParserException {
+        int[] rolls = {3, 6, 6, 2}; // explode both sixes
+        setUpMockRunData(rolls);
+        Result result = new ExpressionParser().evaluate("2d6e");
+        assertEquals(new BigDecimal(17), result.getValue());
+    }
+
+    public void testEvaluate_DropWithMockRunData() throws ParserException {
+        int[] rolls = {6, 2, 5, 4, 1, 6}; // drop 2 and 1
+        setUpMockRunData(rolls);
+        Result result = new ExpressionParser().evaluate("6d6d2");
+        assertEquals(new BigDecimal(21), result.getValue());
+    }
+
+    public void testEvaluate_KeepWithMockRunData() throws ParserException {
+        int[] rolls = {6, 2, 5, 4, 1, 6}; // keep the sixes and the 5
+        setUpMockRunData(rolls);
+        Result result = new ExpressionParser().evaluate("6d6k3");
+        assertEquals(new BigDecimal(17), result.getValue());
+    }
+
+    public void testEvaluate_CountSuccessesWithMockRunData() throws ParserException {
+        int[] rolls = {6, 2, 5, 4, 1, 6}; // count the 5 and 6s
+        setUpMockRunData(rolls);
+        Result result = new ExpressionParser().evaluate("6d6s5");
+        assertEquals(new BigDecimal(3), result.getValue());
+    }
+
+    public void testEvaluate_ExplodingSuccessesWithMockRunData() throws ParserException {
+        int[] rolls = {5, 4, 6, 1, 6, 6, 5};
+        setUpMockRunData(rolls);
+        Result result = new ExpressionParser().evaluate("4d6es8");
+        assertEquals("Dice: 5, 4, 7, 17, Successes: 1", result.getValue());
+    }
+
+    public void testEvaluate_OpenWithMockRunData() throws ParserException {
+        int[] rolls = {5, 6, 4, 6, 6, 2, 3};
+        setUpMockRunData(rolls);
+        Result result = new ExpressionParser().evaluate("4d6o");
+        assertEquals("Dice: 5, 10, 14, 3, Maximum: 14", result.getValue());
+    }
+
+    public void testEvaluate_DropHighWithMockRunData() throws ParserException {
+        int[] rolls = {6, 2, 5, 4, 1, 6}; // drop 6s and 5
+        setUpMockRunData(rolls);
+        Result result = new ExpressionParser().evaluate("6d6dh3");
+        assertEquals(new BigDecimal(7), result.getValue());
+    }
+
+    public void testEvaluate_KeepLowWithMockRunData() throws ParserException {
+        int[] rolls = {6, 2, 5, 4, 1, 6}; // keep the 1 and 2
+        setUpMockRunData(rolls);
+        Result result = new ExpressionParser().evaluate("6d6kl2");
+        assertEquals(new BigDecimal(3), result.getValue());
+    }
+
+    public void testEvaluate_FudgeRollWithMockRunData() throws ParserException {
+        int[] rolls = {1, 2, 2, 3}; // fudge dice are weird - they're shifted d3s to equal -1, 0, 1
+        setUpMockRunData(rolls);
+        Result result = new ExpressionParser().evaluate("4df");
+        assertEquals(BigDecimal.ZERO, result.getValue());
+    }
+}

--- a/src/test/java/net/rptools/common/expression/RunDataMockForTesting.java
+++ b/src/test/java/net/rptools/common/expression/RunDataMockForTesting.java
@@ -1,0 +1,108 @@
+package net.rptools.common.expression;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.logging.Logger;
+
+/**
+ * A version of RunData that replaces the random integer generation with a queue of preconfigured "rolls".  Useful for testing evaluation of dice expressions against a deliberately crafted sequence of rolled values.
+ */
+public class RunDataMockForTesting extends RunData {
+    private static final Logger log = Logger.getLogger(RunDataMockForTesting.class.getName());
+    private final Queue<Integer> toRoll = new LinkedList<>();
+
+    /**
+     * Construct the RunData with desired sequence of values to return as "roll" results.
+     *
+     * @param result the Result object, required by {@link RunData}
+     * @param rolls  the roll values to return, in order
+     */
+    public RunDataMockForTesting(Result result, int[] rolls) {
+        super(result);
+        for (int i : rolls)
+            toRoll.add(i);
+    }
+
+    /**
+     * Gets the next value from the pre-configured queue, or throws an exception if the queue is empty.
+     *
+     * @return the next value, if any
+     * @throws ArrayIndexOutOfBoundsException if the queue is empty
+     */
+    private int getNextInt() {
+        Integer next = toRoll.poll();
+        if (next == null)
+            throw new ArrayIndexOutOfBoundsException("Requested more rolls than were provided to the RunDataMock");
+        log.fine("Providing next pre-configured roll: " + next);
+        rolled.add(next);
+        return next;
+    }
+
+    /**
+     * Gets the next value from the pre-configured queue.  If that value would be greater than maxValue, an exception is thrown instead.
+     *
+     * @param maxValue the upper bound
+     * @return an integer less than or equal to maxValue
+     * @throws IllegalArgumentException if maxValue is too low for the next pre-configured roll
+     */
+    @Override
+    public int randomInt(int maxValue) {
+        int next = getNextInt();
+        if (next > maxValue)
+            throw new IllegalArgumentException("The given maxValue is too low for the next configured roll: " + next);
+        return next;
+    }
+
+    /**
+     * Gets the next N values from the pre-configured queue.  If any of those values would be greater than maxValue, an exception is thrown instead.
+     *
+     * @param num      the desired number of rolls (N)
+     * @param maxValue the upper bound
+     * @return integers less than or equal to maxValue
+     * @throws IllegalArgumentException if maxValue is too low for the next N pre-configured rolls
+     */
+    @Override
+    public int[] randomInts(int num, int maxValue) {
+        int[] ret = new int[num];
+        for (int i = 0; i < num; i++) {
+            ret[i] = randomInt(maxValue);
+        }
+        return ret;
+    }
+
+    /**
+     * Gets the next value from the pre-configured queue.  If that value would be less than minValue or greater than maxValue, an exception is thrown instead.
+     *
+     * @param minValue the lower bound
+     * @param maxValue the upper bound
+     * @return an integer less than or equal to maxValue
+     * @throws IllegalArgumentException if minValue is too high or maxValue is too low for the next pre-configured roll
+     */
+    @Override
+    public int randomInt(int minValue, int maxValue) {
+        int next = getNextInt();
+        if (next < minValue)
+            throw new IllegalArgumentException("The given minValue is too high for the next configured roll: " + next);
+        if (next > maxValue)
+            throw new IllegalArgumentException("The given maxValue is too low for the next configured roll: " + next);
+        return next;
+    }
+
+    /**
+     * Gets the next N values from the pre-configured queue.  If any of those values would be less than minValue or greater than maxValue, an exception is thrown instead.
+     *
+     * @param num      the desired number of rolls (N)
+     * @param minValue the lower bound
+     * @param maxValue the upper bound
+     * @return integers less than or equal to maxValue
+     * @throws IllegalArgumentException if minValue is too high or maxValue is too low for the next N pre-configured rolls
+     */
+    @Override
+    public int[] randomInts(int num, int minValue, int maxValue) {
+        int[] ret = new int[num];
+        for (int i = 0; i < num; i++) {
+            ret[i] = randomInt(minValue, maxValue);
+        }
+        return ret;
+    }
+}


### PR DESCRIPTION
- Extends RunData to add a version that produces a pre-configured sequence of "rolls" for testing
- Adds a number of Dice Expression tests that verify expected behavior against specified sequences of rolls
- Adjusts ExpressionParser to not discard the RunData set as the thread's `current` instance

Fixes #28

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/dicelib/29)
<!-- Reviewable:end -->
