### PR TITLE
Validate input to keep() and keepLowest() to avoid ArrayIndexOutOfBounds errors

### DIFF
--- a/src/main/java/net/rptools/common/expression/function/DiceHelper.java
+++ b/src/main/java/net/rptools/common/expression/function/DiceHelper.java
@@ -66,10 +66,12 @@ public class DiceHelper {
   }
 
   public static int keepDice(int times, int sides, int keep) throws EvaluationException {
+    if (keep > times) throw new EvaluationException("You cannot keep more dice than you roll");
     return dropDice(times, sides, times - keep);
   }
 
   public static int keepLowestDice(int times, int sides, int keep) throws EvaluationException {
+    if (keep > times) throw new EvaluationException("You cannot keep more dice than you roll");
     return dropDiceHighest(times, sides, times - keep);
   }
 

--- a/src/test/java/net/rptools/common/expression/ExpressionParserTest.java
+++ b/src/test/java/net/rptools/common/expression/ExpressionParserTest.java
@@ -20,6 +20,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import junit.framework.TestCase;
 import net.rptools.parser.ParserException;
+import net.rptools.parser.function.EvaluationException;
 
 public class ExpressionParserTest extends TestCase {
 
@@ -51,6 +52,24 @@ public class ExpressionParserTest extends TestCase {
     Result result = new ExpressionParser().evaluate("100+10d6k8+1");
 
     assertEquals(new BigDecimal(138), result.getValue());
+  }
+
+  public void testEvaluate_Keep_error_tooManyDice() throws ParserException {
+    try {
+      Result result = new ExpressionParser().evaluate("2d6k4");
+      fail("Expected EvaluationException from trying to keep too many dice");
+    } catch (EvaluationException expected) {
+      // test passes if expected exception is produced
+    }
+  }
+
+  public void testEvaluate_KeepLowest_error_tooManyDice() throws ParserException {
+    try {
+      Result result = new ExpressionParser().evaluate("2d6kl4");
+      fail("Expected EvaluationException from trying to keep too many dice");
+    } catch (EvaluationException expected) {
+      // test passes if expected exception is produced
+    }
   }
 
   public void testEvaluate_RerollOnceAndKeep() throws ParserException {

--- a/src/test/java/net/rptools/common/expression/ExpressionParserWithMockRollsTest.java
+++ b/src/test/java/net/rptools/common/expression/ExpressionParserWithMockRollsTest.java
@@ -54,6 +54,13 @@ public class ExpressionParserWithMockRollsTest extends TestCase {
     assertEquals(new BigDecimal(17), result.getValue());
   }
 
+  public void testEvaluate_KeepLowestWithMockRunData() throws ParserException {
+    int[] rolls = {6, 2, 5, 4, 1, 6}; // keep the 1 and 2
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("6d6kl2");
+    assertEquals(new BigDecimal(3), result.getValue());
+  }
+
   public void testEvaluate_RerollOnceAndKeepWithMockRunData() throws ParserException {
     int[] rolls = {4, 2, 1}; // the 2 will be re-rolled, and the 1 will be kept
     RunDataMockForTesting mockRD = new RunDataMockForTesting(new Result(""), rolls);
@@ -68,7 +75,9 @@ public class ExpressionParserWithMockRollsTest extends TestCase {
     RunData.setCurrent(mockRD);
     Result result = new ExpressionParser().evaluate("2d6rc3");
     assertEquals(new BigDecimal(6), result.getValue());
-  }public void testEvaluate_CountSuccessesWithMockRunData() throws ParserException {
+  }
+
+  public void testEvaluate_CountSuccessesWithMockRunData() throws ParserException {
     int[] rolls = {6, 2, 5, 4, 1, 6}; // count the 5 and 6s
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("6d6s5");


### PR DESCRIPTION
Fixes rptools/dicelib#33

Includes tests to expect EvaluationExceptions when attempting to keep too many dice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/dicelib/34)
<!-- Reviewable:end -->
