### PR TITLE
Fix functions returning 0d0 rolls when invoked with improper case - n…

### DIFF
--- a/src/main/java/net/rptools/common/expression/function/RollWithBounds.java
+++ b/src/main/java/net/rptools/common/expression/function/RollWithBounds.java
@@ -72,6 +72,8 @@ public class RollWithBounds extends AbstractNumberFunction {
         mod = ((BigDecimal) parameters.get(2)).intValue();
         lower = ((BigDecimal) parameters.get(3)).intValue();
         break;
+      default:
+        throw new ParserException("Unknown function name: " + functionName);
     }
     return DiceHelper.rollModWithBounds(times, sides, mod, lower, upper);
   }


### PR DESCRIPTION
…ow throw ParserExceptions instead.

Part of RPTools/maptool#2041
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/dicelib/53)
<!-- Reviewable:end -->
