### PR TITLE
Make dicelib compatible with refactor to Parser

### DIFF
--- a/src/main/java/net/rptools/common/expression/ExpressionParser.java
+++ b/src/main/java/net/rptools/common/expression/ExpressionParser.java
@@ -15,10 +15,7 @@
 package net.rptools.common.expression;
 
 import net.rptools.common.expression.function.*;
-import net.rptools.parser.Expression;
-import net.rptools.parser.Parser;
-import net.rptools.parser.ParserException;
-import net.rptools.parser.VariableResolver;
+import net.rptools.parser.*;
 import net.rptools.parser.transform.RegexpStringTransformer;
 import net.rptools.parser.transform.StringLiteralTransformer;
 
@@ -175,16 +172,9 @@ public class ExpressionParser {
     this(DICE_PATTERNS);
   }
 
-  public ExpressionParser(VariableResolver resolver) {
-    this(DICE_PATTERNS, resolver);
-  }
-
   public ExpressionParser(String[][] regexpTransforms) {
-    this(regexpTransforms, null);
-  }
 
-  public ExpressionParser(String[][] regexpTransforms, VariableResolver resolver) {
-    parser = new Parser(resolver, true);
+    parser = createParser();
 
     parser.addFunction(new CountSuccessDice());
     parser.addFunction(new DropRoll());
@@ -215,15 +205,24 @@ public class ExpressionParser {
     parser.addTransformer(slt.getReplaceTransformer());
   }
 
+  protected Parser createParser() {
+    return new Parser();
+  }
+
   public Parser getParser() {
     return parser;
   }
 
   public Result evaluate(String expression) throws ParserException {
-    return evaluate(expression, true);
+    return evaluate(expression, new MapVariableResolver(), true);
   }
 
-  public Result evaluate(String expression, boolean makeDeterministic) throws ParserException {
+  public Result evaluate(String expression, VariableResolver resolver) throws ParserException {
+    return evaluate(expression, resolver, true);
+  }
+
+  public Result evaluate(String expression, VariableResolver resolver, boolean makeDeterministic)
+      throws ParserException {
     Result ret = new Result(expression);
     RunData oldData = RunData.hasCurrent() ? RunData.getCurrent() : null;
     try {
@@ -236,13 +235,12 @@ public class ExpressionParser {
       RunData.setCurrent(newRunData);
 
       synchronized (parser) {
-        Expression xp = parser.parseExpression(expression);
-
-        if (makeDeterministic) {
-          xp = xp.getDeterministicExpression();
-        }
-        ret.setDetailExpression(xp.format());
-        ret.setValue(xp.evaluate());
+        final Expression xp =
+            makeDeterministic
+                ? parser.parseExpression(expression).getDeterministicExpression(resolver)
+                : parser.parseExpression(expression);
+        ret.setDetailExpression(() -> xp.format());
+        ret.setValue(xp.evaluate(resolver));
         ret.setRolled(newRunData.getRolled());
       }
     } finally {

--- a/src/main/java/net/rptools/common/expression/Result.java
+++ b/src/main/java/net/rptools/common/expression/Result.java
@@ -19,10 +19,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class Result {
   private final String expression;
-  private String detailExpression;
+  private Supplier<String> detailExpression;
   private Object value;
   private String description;
   private List<Integer> rolled;
@@ -38,10 +39,10 @@ public class Result {
   }
 
   public String getDetailExpression() {
-    return detailExpression;
+    return detailExpression != null ? detailExpression.get() : "";
   }
 
-  public void setDetailExpression(String detailExpression) {
+  public void setDetailExpression(Supplier<String> detailExpression) {
     this.detailExpression = detailExpression;
   }
 

--- a/src/main/java/net/rptools/common/expression/function/ArsMagicaStress.java
+++ b/src/main/java/net/rptools/common/expression/function/ArsMagicaStress.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 
 public class ArsMagicaStress extends AbstractNumberFunction {
@@ -27,7 +28,8 @@ public class ArsMagicaStress extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
 
     int botchDice = ((BigDecimal) parameters.get(0)).intValue();

--- a/src/main/java/net/rptools/common/expression/function/CountSuccessDice.java
+++ b/src/main/java/net/rptools/common/expression/function/CountSuccessDice.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class CountSuccessDice extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();

--- a/src/main/java/net/rptools/common/expression/function/DropHighestRoll.java
+++ b/src/main/java/net/rptools/common/expression/function/DropHighestRoll.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class DropHighestRoll extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();

--- a/src/main/java/net/rptools/common/expression/function/DropRoll.java
+++ b/src/main/java/net/rptools/common/expression/function/DropRoll.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class DropRoll extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();

--- a/src/main/java/net/rptools/common/expression/function/ExplodeDice.java
+++ b/src/main/java/net/rptools/common/expression/function/ExplodeDice.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class ExplodeDice extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();

--- a/src/main/java/net/rptools/common/expression/function/ExplodingSuccessDice.java
+++ b/src/main/java/net/rptools/common/expression/function/ExplodingSuccessDice.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class ExplodingSuccessDice extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();

--- a/src/main/java/net/rptools/common/expression/function/FudgeRoll.java
+++ b/src/main/java/net/rptools/common/expression/function/FudgeRoll.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 
 /**
@@ -34,7 +35,8 @@ public class FudgeRoll extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters) {
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters) {
     int n = 0;
 
     int times = 1;

--- a/src/main/java/net/rptools/common/expression/function/HeroKillingRoll.java
+++ b/src/main/java/net/rptools/common/expression/function/HeroKillingRoll.java
@@ -37,7 +37,8 @@ public class HeroKillingRoll extends AbstractNumberFunction {
   private static String lastKillingBodyVar = "#Hero-LastKillingBodyVar";
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver vr, String functionName, List<Object> parameters)
       throws ParserException {
     int n = 0;
 
@@ -47,7 +48,6 @@ public class HeroKillingRoll extends AbstractNumberFunction {
     int extra = 0;
     if (parameters.size() > 2) extra = ((BigDecimal) parameters.get(n++)).intValue();
 
-    VariableResolver vr = parser.getVariableResolver();
     RunData runData = RunData.getCurrent();
 
     if (functionName.equalsIgnoreCase("herokilling")) {
@@ -70,7 +70,7 @@ public class HeroKillingRoll extends AbstractNumberFunction {
         body++;
       }
 
-      parser.setVariable(lastKillingBodyVar, new BigDecimal(body));
+      vr.setVariable(lastKillingBodyVar, new BigDecimal(body));
       return new BigDecimal(body);
     } else if (functionName.equalsIgnoreCase("herokilling2")) {
 
@@ -93,7 +93,7 @@ public class HeroKillingRoll extends AbstractNumberFunction {
         body++;
       }
 
-      parser.setVariable(lastKillingBodyVar, new BigDecimal(body));
+      vr.setVariable(lastKillingBodyVar, new BigDecimal(body));
       return new BigDecimal(body);
     } else {
       int multi = DiceHelper.rollDice((int) times, sides);

--- a/src/main/java/net/rptools/common/expression/function/HeroRoll.java
+++ b/src/main/java/net/rptools/common/expression/function/HeroRoll.java
@@ -39,14 +39,13 @@ public class HeroRoll extends AbstractNumberFunction {
   private static String lastBodyVar = "#Hero-LastBodyVar";
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver vr, String functionName, List<Object> parameters)
       throws ParserException {
     int n = 0;
 
     double times = ((BigDecimal) parameters.get(n++)).doubleValue();
     int sides = ((BigDecimal) parameters.get(n++)).intValue();
-
-    VariableResolver vr = parser.getVariableResolver();
 
     if (functionName.equalsIgnoreCase("herobody")) {
       double lastTimes = 0;
@@ -104,9 +103,9 @@ public class HeroRoll extends AbstractNumberFunction {
         stun += (die + 1) / 2;
       }
 
-      parser.setVariable(lastTimesVar, new BigDecimal(lastTimes));
-      parser.setVariable(lastSidesVar, new BigDecimal(lastSides));
-      parser.setVariable(lastBodyVar, new BigDecimal(lastBody));
+      vr.setVariable(lastTimesVar, new BigDecimal(lastTimes));
+      vr.setVariable(lastSidesVar, new BigDecimal(lastSides));
+      vr.setVariable(lastBodyVar, new BigDecimal(lastBody));
 
       return new BigDecimal(stun);
     }

--- a/src/main/java/net/rptools/common/expression/function/If.java
+++ b/src/main/java/net/rptools/common/expression/function/If.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class If extends AbstractFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
     if (BigDecimal.ZERO.equals((BigDecimal) parameters.get(0))) return parameters.get(2);
 

--- a/src/main/java/net/rptools/common/expression/function/KeepLowestRoll.java
+++ b/src/main/java/net/rptools/common/expression/function/KeepLowestRoll.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class KeepLowestRoll extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();

--- a/src/main/java/net/rptools/common/expression/function/KeepRoll.java
+++ b/src/main/java/net/rptools/common/expression/function/KeepRoll.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class KeepRoll extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();

--- a/src/main/java/net/rptools/common/expression/function/OpenTestDice.java
+++ b/src/main/java/net/rptools/common/expression/function/OpenTestDice.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class OpenTestDice extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();

--- a/src/main/java/net/rptools/common/expression/function/RerollDice.java
+++ b/src/main/java/net/rptools/common/expression/function/RerollDice.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class RerollDice extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();

--- a/src/main/java/net/rptools/common/expression/function/RerollDiceOnce.java
+++ b/src/main/java/net/rptools/common/expression/function/RerollDiceOnce.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -34,7 +35,8 @@ public class RerollDiceOnce extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
     int n = 0;
     int times = ((BigDecimal) parameters.get(n++)).intValue();

--- a/src/main/java/net/rptools/common/expression/function/Roll.java
+++ b/src/main/java/net/rptools/common/expression/function/Roll.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 
 /**
@@ -34,7 +35,8 @@ public class Roll extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters) {
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters) {
     int n = 0;
 
     int times = 1;

--- a/src/main/java/net/rptools/common/expression/function/RollWithBounds.java
+++ b/src/main/java/net/rptools/common/expression/function/RollWithBounds.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 
 public class RollWithBounds extends AbstractNumberFunction {
@@ -35,7 +36,8 @@ public class RollWithBounds extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws ParserException {
     int times = 0;
     int sides = 0;

--- a/src/main/java/net/rptools/common/expression/function/ShadowRun4Dice.java
+++ b/src/main/java/net/rptools/common/expression/function/ShadowRun4Dice.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class ShadowRun4Dice extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
 
     int n = 0;

--- a/src/main/java/net/rptools/common/expression/function/ShadowRun4ExplodeDice.java
+++ b/src/main/java/net/rptools/common/expression/function/ShadowRun4ExplodeDice.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
@@ -27,7 +28,8 @@ public class ShadowRun4ExplodeDice extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters)
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
       throws EvaluationException {
 
     int n = 0;

--- a/src/main/java/net/rptools/common/expression/function/UbiquityRoll.java
+++ b/src/main/java/net/rptools/common/expression/function/UbiquityRoll.java
@@ -17,6 +17,7 @@ package net.rptools.common.expression.function;
 import java.math.BigDecimal;
 import java.util.List;
 import net.rptools.parser.Parser;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 
 /**
@@ -34,7 +35,8 @@ public class UbiquityRoll extends AbstractNumberFunction {
   }
 
   @Override
-  public Object childEvaluate(Parser parser, String functionName, List<Object> parameters) {
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters) {
     int n = 0;
 
     int times = 1;

--- a/src/test/java/net/rptools/common/expression/ExpressionParserTest.java
+++ b/src/test/java/net/rptools/common/expression/ExpressionParserTest.java
@@ -19,7 +19,9 @@ import java.math.BigInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import junit.framework.TestCase;
+import net.rptools.parser.MapVariableResolver;
 import net.rptools.parser.ParserException;
+import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.EvaluationException;
 
 public class ExpressionParserTest extends TestCase {
@@ -156,21 +158,29 @@ public class ExpressionParserTest extends TestCase {
   public void testEvaluate_HeroRoll() throws ParserException {
     RunData.setSeed(10423L);
     ExpressionParser parser = new ExpressionParser();
+    VariableResolver resolver = new MapVariableResolver();
 
-    Result result = parser.evaluate("4.5d6h");
+    Result result = parser.evaluate("4.5d6h", resolver);
     assertEquals(new BigDecimal(18), result.getValue());
 
-    result = parser.evaluate("4.5d6b");
+    result = parser.evaluate("4.5d6b", resolver);
     assertEquals(new BigDecimal(5), result.getValue());
 
     RunData.setSeed(10423L);
     parser = new ExpressionParser();
+    resolver = new MapVariableResolver();
 
-    result = parser.evaluate("4d6h");
+    result = parser.evaluate("4d6h", resolver);
     assertEquals(new BigDecimal(15), result.getValue());
 
-    result = parser.evaluate("4d6b");
+    result = parser.evaluate("4d6b", resolver);
     assertEquals(new BigDecimal(4), result.getValue());
+  }
+
+  private VariableResolver initVar(String name, Object value) throws ParserException {
+    VariableResolver result = new MapVariableResolver();
+    result.setVariable(name, value);
+    return result;
   }
 
   public void testEvaluate_FudgeRoll() throws ParserException {
@@ -184,8 +194,7 @@ public class ExpressionParserTest extends TestCase {
     assertEquals(new BigDecimal(0), result.getValue());
 
     // Don't parse df in the middle of things
-    parser.getParser().getVariableResolver().setVariable("asdfg", new BigDecimal(10));
-    result = parser.evaluate("asdfg");
+    result = parser.evaluate("asdfg", initVar("asdfg", new BigDecimal(10)));
     assertEquals(new BigDecimal(10), result.getValue());
   }
 
@@ -200,8 +209,7 @@ public class ExpressionParserTest extends TestCase {
     assertEquals(new BigDecimal(4), result.getValue());
 
     // Don't parse a uf in the middle of other things
-    parser.getParser().getVariableResolver().setVariable("asufg", new BigDecimal(10));
-    result = parser.evaluate("asufg");
+    result = parser.evaluate("asufg", initVar("asufg", new BigDecimal(10)));
     assertEquals(new BigDecimal(10), result.getValue());
   }
 
@@ -261,9 +269,8 @@ public class ExpressionParserTest extends TestCase {
 
   public void testVariableRegexOverlaps() throws ParserException {
     ExpressionParser parser = new ExpressionParser();
-    parser.getParser().setVariable("food10", new BigDecimal(10));
-
-    evaluateExpression(parser, "food10 + 10", new BigDecimal(20));
+    Result result = parser.evaluate("food10 + 10", initVar("food10", new BigDecimal(10)));
+    assertEquals(new BigDecimal(20), result.getValue());
   }
 
   public void testNonDetailedExpression() throws ParserException {
@@ -271,27 +278,26 @@ public class ExpressionParserTest extends TestCase {
 
     int[] flattenings = new int[] {0};
 
-    parser
-        .getParser()
-        .setVariable(
-            "anumber",
-            new BigDecimal(3) {
-              @Override
-              public String toString() {
-                flattenings[0]++;
-                return super.toString();
-              }
-            });
+    MapVariableResolver resolver = new MapVariableResolver();
+    resolver.setVariable(
+        "anumber",
+        new BigDecimal(3) {
+          @Override
+          public String toString() {
+            flattenings[0]++;
+            return super.toString();
+          }
+        });
 
     // one evaluation with detailed expression (the default)
-    Result result = parser.evaluate("anumber + 1", true);
+    Result result = parser.evaluate("anumber + 1", resolver, true);
     assertEquals("anumber + 1", result.getExpression());
     assertEquals("3 + 1", result.getDetailExpression());
     assertEquals(new BigDecimal(4), result.getValue());
 
     // one evaluation without detailed expression (this makes dicelib not go through a deterministic
     // expression)
-    result = parser.evaluate("anumber + 1", false);
+    result = parser.evaluate("anumber + 1", resolver, false);
     assertEquals("anumber + 1", result.getExpression());
     assertEquals("anumber + 1", result.getDetailExpression());
     assertEquals(new BigDecimal(4), result.getValue());

--- a/src/test/java/net/rptools/common/expression/function/RollTest.java
+++ b/src/test/java/net/rptools/common/expression/function/RollTest.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import junit.framework.TestCase;
 import net.rptools.common.expression.RunData;
 import net.rptools.parser.Expression;
+import net.rptools.parser.MapVariableResolver;
 import net.rptools.parser.Parser;
 import net.rptools.parser.ParserException;
 import net.rptools.parser.function.EvaluationException;
@@ -52,7 +53,7 @@ public class RollTest extends TestCase {
       RunData.setCurrent(new RunData(null));
 
       Expression xp = p.parseExpression("roll(10, 6) + 10");
-      Expression dxp = xp.getDeterministicExpression();
+      Expression dxp = xp.getDeterministicExpression(new MapVariableResolver());
 
       assertTrue(dxp.format().matches("\\d+ \\+ 10"));
     } finally {


### PR DESCRIPTION
Compatible API changes to https://github.com/RPTools/parser/pull/45

Supports API where VariableResolver is an evaluation time argument so clients can re-use Expressions, once parsed, multiple times over.

Changes:
 * refactor all functions that now get the variable resolver as argument
 * update unittest
 * update ExpressionParser with a protected method that allows overriding Parser (will be used in MapTool)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/dicelib/57)
<!-- Reviewable:end -->
