### PR TITLE
ShadowRun 5 Dice Roll

### DIFF
--- a/src/main/java/net/rptools/common/expression/ExpressionParser.java
+++ b/src/main/java/net/rptools/common/expression/ExpressionParser.java
@@ -133,6 +133,14 @@ public class ExpressionParser {
         new String[] {"\\b(\\d+)[sS][rR]4[gG](\\d+)\\b", "sr4($1, $2)"},
         new String[] {"\\b(\\d+)[sS][rR]4\\b", "sr4($1)"},
 
+        // Shadowrun 5 Edge or Exploding Test
+        new String[] {"\\b(\\d+)[sS][rR]5[eE][gG](\\d+)\\b", "sr5e($1, $2)"},
+        new String[] {"\\b(\\d+)[sS][rR]5[eE]\\b", "sr5e($1)"},
+
+        // Shadowrun 5 Normal Test
+        new String[] {"\\b(\\d+)[sS][rR]5[gG](\\d+)\\b", "sr5($1, $2)"},
+        new String[] {"\\b(\\d+)[sS][rR]5\\b", "sr5($1)"},
+
         // Subtract X with minimum of Y
         new String[] {
           "\\b(\\d+)[dD](\\d+)[sS](\\d+)[lL](\\d+)\\b", "rollSubWithLower($1, $2, $3, $4)"
@@ -188,6 +196,8 @@ public class ExpressionParser {
     parser.addFunction(new UbiquityRoll());
     parser.addFunction(new ShadowRun4Dice());
     parser.addFunction(new ShadowRun4ExplodeDice());
+    parser.addFunction(new ShadowRun5Dice());
+    parser.addFunction(new ShadowRun5ExplodeDice());
     parser.addFunction(new Roll());
     parser.addFunction(new ExplodingSuccessDice());
     parser.addFunction(new OpenTestDice());

--- a/src/main/java/net/rptools/common/expression/function/ShadowRun4Dice.java
+++ b/src/main/java/net/rptools/common/expression/function/ShadowRun4Dice.java
@@ -37,6 +37,6 @@ public class ShadowRun4Dice extends AbstractNumberFunction {
     int times = ((BigDecimal) parameters.get(n++)).intValue();
     if (parameters.size() == 2) gremlins = ((BigDecimal) parameters.get(n++)).intValue();
 
-    return DiceHelper.countShadowRun4(times, gremlins, false);
+    return DiceHelper.countShadowRun(times, gremlins, false, DiceHelper.ShadowrunEdition.EDITION_4);
   }
 }

--- a/src/main/java/net/rptools/common/expression/function/ShadowRun4ExplodeDice.java
+++ b/src/main/java/net/rptools/common/expression/function/ShadowRun4ExplodeDice.java
@@ -16,7 +16,6 @@ package net.rptools.common.expression.function;
 
 import java.math.BigDecimal;
 import java.util.List;
-
 import net.rptools.parser.Parser;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
@@ -24,20 +23,20 @@ import net.rptools.parser.function.EvaluationException;
 
 public class ShadowRun4ExplodeDice extends AbstractNumberFunction {
 
-    public ShadowRun4ExplodeDice() {
-        super(1, 2, true, "sr4e");
-    }
+  public ShadowRun4ExplodeDice() {
+    super(1, 2, true, "sr4e");
+  }
 
-    @Override
-    public Object childEvaluate(
-            Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
-            throws EvaluationException {
+  @Override
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
+      throws EvaluationException {
 
-        int n = 0;
-        int gremlins = 0;
-        int times = ((BigDecimal) parameters.get(n++)).intValue();
-        if (parameters.size() == 2) gremlins = ((BigDecimal) parameters.get(n++)).intValue();
+    int n = 0;
+    int gremlins = 0;
+    int times = ((BigDecimal) parameters.get(n++)).intValue();
+    if (parameters.size() == 2) gremlins = ((BigDecimal) parameters.get(n++)).intValue();
 
-        return DiceHelper.countShadowRun(times, gremlins, true, DiceHelper.ShadowrunEdition.EDITION_4);
-    }
+    return DiceHelper.countShadowRun(times, gremlins, true, DiceHelper.ShadowrunEdition.EDITION_4);
+  }
 }

--- a/src/main/java/net/rptools/common/expression/function/ShadowRun5Dice.java
+++ b/src/main/java/net/rptools/common/expression/function/ShadowRun5Dice.java
@@ -14,13 +14,12 @@
  */
 package net.rptools.common.expression.function;
 
+import java.math.BigDecimal;
+import java.util.List;
 import net.rptools.parser.Parser;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
-
-import java.math.BigDecimal;
-import java.util.List;
 
 public class ShadowRun5Dice extends AbstractNumberFunction {
 

--- a/src/main/java/net/rptools/common/expression/function/ShadowRun5Dice.java
+++ b/src/main/java/net/rptools/common/expression/function/ShadowRun5Dice.java
@@ -14,30 +14,30 @@
  */
 package net.rptools.common.expression.function;
 
-import java.math.BigDecimal;
-import java.util.List;
-
 import net.rptools.parser.Parser;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
-public class ShadowRun4ExplodeDice extends AbstractNumberFunction {
+import java.math.BigDecimal;
+import java.util.List;
 
-    public ShadowRun4ExplodeDice() {
-        super(1, 2, true, "sr4e");
-    }
+public class ShadowRun5Dice extends AbstractNumberFunction {
 
-    @Override
-    public Object childEvaluate(
-            Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
-            throws EvaluationException {
+  public ShadowRun5Dice() {
+    super(1, 2, true, "sr5");
+  }
 
-        int n = 0;
-        int gremlins = 0;
-        int times = ((BigDecimal) parameters.get(n++)).intValue();
-        if (parameters.size() == 2) gremlins = ((BigDecimal) parameters.get(n++)).intValue();
+  @Override
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
+      throws EvaluationException {
 
-        return DiceHelper.countShadowRun(times, gremlins, true, DiceHelper.ShadowrunEdition.EDITION_4);
-    }
+    int n = 0;
+    int gremlins = 0;
+    int times = ((BigDecimal) parameters.get(n++)).intValue();
+    if (parameters.size() == 2) gremlins = ((BigDecimal) parameters.get(n++)).intValue();
+
+    return DiceHelper.countShadowRun(times, gremlins, false, DiceHelper.ShadowrunEdition.EDITION_5);
+  }
 }

--- a/src/main/java/net/rptools/common/expression/function/ShadowRun5ExplodeDice.java
+++ b/src/main/java/net/rptools/common/expression/function/ShadowRun5ExplodeDice.java
@@ -14,30 +14,30 @@
  */
 package net.rptools.common.expression.function;
 
-import java.math.BigDecimal;
-import java.util.List;
-
 import net.rptools.parser.Parser;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
 
-public class ShadowRun4ExplodeDice extends AbstractNumberFunction {
+import java.math.BigDecimal;
+import java.util.List;
 
-    public ShadowRun4ExplodeDice() {
-        super(1, 2, true, "sr4e");
-    }
+public class ShadowRun5ExplodeDice extends AbstractNumberFunction {
 
-    @Override
-    public Object childEvaluate(
-            Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
-            throws EvaluationException {
+  public ShadowRun5ExplodeDice() {
+    super(1, 2, true, "sr5e");
+  }
 
-        int n = 0;
-        int gremlins = 0;
-        int times = ((BigDecimal) parameters.get(n++)).intValue();
-        if (parameters.size() == 2) gremlins = ((BigDecimal) parameters.get(n++)).intValue();
+  @Override
+  public Object childEvaluate(
+      Parser parser, VariableResolver resolver, String functionName, List<Object> parameters)
+      throws EvaluationException {
 
-        return DiceHelper.countShadowRun(times, gremlins, true, DiceHelper.ShadowrunEdition.EDITION_4);
-    }
+    int n = 0;
+    int gremlins = 0;
+    int times = ((BigDecimal) parameters.get(n++)).intValue();
+    if (parameters.size() == 2) gremlins = ((BigDecimal) parameters.get(n++)).intValue();
+
+    return DiceHelper.countShadowRun(times, gremlins, true, DiceHelper.ShadowrunEdition.EDITION_5);
+  }
 }

--- a/src/main/java/net/rptools/common/expression/function/ShadowRun5ExplodeDice.java
+++ b/src/main/java/net/rptools/common/expression/function/ShadowRun5ExplodeDice.java
@@ -14,13 +14,12 @@
  */
 package net.rptools.common.expression.function;
 
+import java.math.BigDecimal;
+import java.util.List;
 import net.rptools.parser.Parser;
 import net.rptools.parser.VariableResolver;
 import net.rptools.parser.function.AbstractNumberFunction;
 import net.rptools.parser.function.EvaluationException;
-
-import java.math.BigDecimal;
-import java.util.List;
 
 public class ShadowRun5ExplodeDice extends AbstractNumberFunction {
 

--- a/src/test/java/net/rptools/common/expression/ExpressionParserTest.java
+++ b/src/test/java/net/rptools/common/expression/ExpressionParserTest.java
@@ -136,7 +136,7 @@ public class ExpressionParserTest extends TestCase {
     Result result = new ExpressionParser().evaluate("5sr4g2");
     assertEquals("5sr4g2", result.getExpression());
     assertEquals("sr4(5, 2)", result.getDetailExpression());
-    assertEquals("Hits: 1 Ones: 1 *Glitch*  Results: 3 1 4 6 3 ", result.getValue());
+    assertEquals("Hits: 1 Ones: 1 *Gremlin Glitch*  Results: 3 1 4 6 3 ", result.getValue());
   }
 
   public void testEvaluate_SR4ExplodingSuccess() throws ParserException {
@@ -152,7 +152,39 @@ public class ExpressionParserTest extends TestCase {
     Result result = new ExpressionParser().evaluate("5sr4eg2");
     assertEquals("5sr4eg2", result.getExpression());
     assertEquals("sr4e(5, 2)", result.getDetailExpression());
-    assertEquals("Hits: 1 Ones: 2 *Glitch*  Results: 3 1 4 6 3 1 ", result.getValue());
+    assertEquals("Hits: 1 Ones: 2 *Gremlin Glitch*  Results: 3 1 4 6 3 1 ", result.getValue());
+  }
+
+  public void testEvaluate_SR5Success() throws ParserException {
+    RunData.setSeed(10523L);
+    Result result = new ExpressionParser().evaluate("5sr5");
+    assertEquals("5sr5", result.getExpression());
+    assertEquals("sr5(5)", result.getDetailExpression());
+    assertEquals("Hits: 1 Ones: 1  Results: 3 1 4 6 3 ", result.getValue());
+  }
+
+  public void testEvaluate_SR5GremlinSuccess() throws ParserException {
+    RunData.setSeed(10523L);
+    Result result = new ExpressionParser().evaluate("5sr5g2");
+    assertEquals("5sr5g2", result.getExpression());
+    assertEquals("sr5(5, 2)", result.getDetailExpression());
+    assertEquals("Hits: 1 Ones: 1 *Gremlin Glitch*  Results: 3 1 4 6 3 ", result.getValue());
+  }
+
+  public void testEvaluate_SR5ExplodingSuccess() throws ParserException {
+    RunData.setSeed(10523L);
+    Result result = new ExpressionParser().evaluate("5sr5e");
+    assertEquals("5sr5e", result.getExpression());
+    assertEquals("sr5e(5)", result.getDetailExpression());
+    assertEquals("Hits: 1 Ones: 2  Results: 3 1 4 6 3 1 ", result.getValue());
+  }
+
+  public void testEvaluate_SR5ExplodingGremlinSuccess() throws ParserException {
+    RunData.setSeed(10523L);
+    Result result = new ExpressionParser().evaluate("5sr5eg2");
+    assertEquals("5sr5eg2", result.getExpression());
+    assertEquals("sr5e(5, 2)", result.getDetailExpression());
+    assertEquals("Hits: 1 Ones: 2 *Gremlin Glitch*  Results: 3 1 4 6 3 1 ", result.getValue());
   }
 
   public void testEvaluate_HeroRoll() throws ParserException {

--- a/src/test/java/net/rptools/common/expression/ExpressionParserWithMockRollsTest.java
+++ b/src/test/java/net/rptools/common/expression/ExpressionParserWithMockRollsTest.java
@@ -33,8 +33,103 @@ public class ExpressionParserWithMockRollsTest extends TestCase {
     RunData.setCurrent(mockRD);
   }
 
+
+  public void testEvaluate_ShadowRun4NonGlich25() throws ParserException {
+    int[] rolls = {2,5}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr4");
+    assertEquals("Hits: 1 Ones: 0  Results: 2 5 ", result.getValue());
+  }
+  public void testEvaluate_ShadowRun4GremlinGlich25() throws ParserException {
+    int[] rolls = {2,5}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr4g1");
+    assertEquals("Hits: 1 Ones: 0 *Gremlin Glitch*  Results: 2 5 ", result.getValue());
+  }
+  public void testEvaluate_ShadowRun4CriticalGremlinGlich22() throws ParserException {
+    int[] rolls = {2,2}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr4g1");
+    assertEquals("Hits: 0 Ones: 0 *Critical Gremlin Glitch*  Results: 2 2 ", result.getValue());
+  }
+  public void testEvaluate_ShadowRun4Glitch15() throws ParserException {
+    int[] rolls = {1,5}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr4");
+    assertEquals("Hits: 1 Ones: 1 *Glitch*  Results: 1 5 ", result.getValue());
+  }
+  public void testEvaluate_ShadowRun4CriticalGlitch12() throws ParserException {
+    int[] rolls = {1,2}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr4");
+    assertEquals("Hits: 0 Ones: 1 *Critical Glitch*  Results: 1 2 ", result.getValue());
+  }
+
+  public void testEvaluate_ShadowRun4CriticalGlitch11() throws ParserException {
+    int[] rolls = {1, 1}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr4");
+    assertEquals("Hits: 0 Ones: 2 *Critical Glitch*  Results: 1 1 ", result.getValue());
+  }
+  public void testEvaluate_ShadowRun5NonGlich25() throws ParserException {
+    int[] rolls = {2,5}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr5");
+    assertEquals("Hits: 1 Ones: 0  Results: 2 5 ", result.getValue());
+  }
+  public void testEvaluate_ShadowRun5NonGlitch15() throws ParserException {
+    int[] rolls = {1,5}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr5");
+    assertEquals("Hits: 1 Ones: 1  Results: 1 5 ", result.getValue());
+  }
+
+  public void testEvaluate_ShadowRun5CriticalGlitch11() throws ParserException {
+    int[] rolls = {1, 1}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr5");
+    assertEquals("Hits: 0 Ones: 2 *Critical Glitch*  Results: 1 1 ", result.getValue());
+  }
+  public void testEvaluate_ShadowRun5CriticalGremlinGlitch12() throws ParserException {
+    int[] rolls = {1, 2}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr5g1");
+    assertEquals("Hits: 0 Ones: 1 *Critical Gremlin Glitch*  Results: 1 2 ", result.getValue());
+  }
+  public void testEvaluate_ShadowRun5GremlinGlitch15() throws ParserException {
+    int[] rolls = {1, 5}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr5g1");
+    assertEquals("Hits: 1 Ones: 1 *Gremlin Glitch*  Results: 1 5 ", result.getValue());
+  }
+  public void testEvaluate_ShadowRun5CriticalNonGremlinGlitch11() throws ParserException {
+    int[] rolls = {1, 1}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr5g1");
+    // This one would have glitched even without gremlins, thus, don't show the gremlin mark
+    assertEquals("Hits: 0 Ones: 2 *Critical Glitch*  Results: 1 1 ", result.getValue());
+  }
+
+  public void testEvaluate_ShadowRun5Glitch61Exploding1() throws ParserException {
+    int[] rolls = {6,1,1}; 
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr5e");
+    assertEquals("Hits: 1 Ones: 2 *Glitch*  Results: 6 1 1 ", result.getValue());
+  }
+  public void testEvaluate_ShadowRun5Glitch66Exploding6611() throws ParserException {
+    int[] rolls = {6,6,6,6,1,1};
+    setUpMockRunData(rolls);
+    Result result = new ExpressionParser().evaluate("2sr5e");
+    // this is still a glitch.
+    assertEquals("Hits: 4 Ones: 2 *Glitch*  Results: 6 6 6 6 1 1 ", result.getValue());
+  }
+
+
+
+
+
   public void testEvaluate_ExplodeWithMockRunData() throws ParserException {
-    int[] rolls = {3, 6, 6, 2}; // explode both sixes
+    int[] rolls = {3, 6, 6, 2}; 
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2d6e");
     assertEquals(new BigDecimal(17), result.getValue());

--- a/src/test/java/net/rptools/common/expression/ExpressionParserWithMockRollsTest.java
+++ b/src/test/java/net/rptools/common/expression/ExpressionParserWithMockRollsTest.java
@@ -33,77 +33,85 @@ public class ExpressionParserWithMockRollsTest extends TestCase {
     RunData.setCurrent(mockRD);
   }
 
-
   public void testEvaluate_ShadowRun4NonGlich25() throws ParserException {
-    int[] rolls = {2,5}; 
+    int[] rolls = {2, 5};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr4");
     assertEquals("Hits: 1 Ones: 0  Results: 2 5 ", result.getValue());
   }
+
   public void testEvaluate_ShadowRun4GremlinGlich25() throws ParserException {
-    int[] rolls = {2,5}; 
+    int[] rolls = {2, 5};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr4g1");
     assertEquals("Hits: 1 Ones: 0 *Gremlin Glitch*  Results: 2 5 ", result.getValue());
   }
+
   public void testEvaluate_ShadowRun4CriticalGremlinGlich22() throws ParserException {
-    int[] rolls = {2,2}; 
+    int[] rolls = {2, 2};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr4g1");
     assertEquals("Hits: 0 Ones: 0 *Critical Gremlin Glitch*  Results: 2 2 ", result.getValue());
   }
+
   public void testEvaluate_ShadowRun4Glitch15() throws ParserException {
-    int[] rolls = {1,5}; 
+    int[] rolls = {1, 5};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr4");
     assertEquals("Hits: 1 Ones: 1 *Glitch*  Results: 1 5 ", result.getValue());
   }
+
   public void testEvaluate_ShadowRun4CriticalGlitch12() throws ParserException {
-    int[] rolls = {1,2}; 
+    int[] rolls = {1, 2};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr4");
     assertEquals("Hits: 0 Ones: 1 *Critical Glitch*  Results: 1 2 ", result.getValue());
   }
 
   public void testEvaluate_ShadowRun4CriticalGlitch11() throws ParserException {
-    int[] rolls = {1, 1}; 
+    int[] rolls = {1, 1};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr4");
     assertEquals("Hits: 0 Ones: 2 *Critical Glitch*  Results: 1 1 ", result.getValue());
   }
+
   public void testEvaluate_ShadowRun5NonGlich25() throws ParserException {
-    int[] rolls = {2,5}; 
+    int[] rolls = {2, 5};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr5");
     assertEquals("Hits: 1 Ones: 0  Results: 2 5 ", result.getValue());
   }
+
   public void testEvaluate_ShadowRun5NonGlitch15() throws ParserException {
-    int[] rolls = {1,5}; 
+    int[] rolls = {1, 5};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr5");
     assertEquals("Hits: 1 Ones: 1  Results: 1 5 ", result.getValue());
   }
 
   public void testEvaluate_ShadowRun5CriticalGlitch11() throws ParserException {
-    int[] rolls = {1, 1}; 
+    int[] rolls = {1, 1};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr5");
     assertEquals("Hits: 0 Ones: 2 *Critical Glitch*  Results: 1 1 ", result.getValue());
   }
+
   public void testEvaluate_ShadowRun5CriticalGremlinGlitch12() throws ParserException {
-    int[] rolls = {1, 2}; 
+    int[] rolls = {1, 2};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr5g1");
     assertEquals("Hits: 0 Ones: 1 *Critical Gremlin Glitch*  Results: 1 2 ", result.getValue());
   }
+
   public void testEvaluate_ShadowRun5GremlinGlitch15() throws ParserException {
-    int[] rolls = {1, 5}; 
+    int[] rolls = {1, 5};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr5g1");
     assertEquals("Hits: 1 Ones: 1 *Gremlin Glitch*  Results: 1 5 ", result.getValue());
   }
+
   public void testEvaluate_ShadowRun5CriticalNonGremlinGlitch11() throws ParserException {
-    int[] rolls = {1, 1}; 
+    int[] rolls = {1, 1};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr5g1");
     // This one would have glitched even without gremlins, thus, don't show the gremlin mark
@@ -111,25 +119,22 @@ public class ExpressionParserWithMockRollsTest extends TestCase {
   }
 
   public void testEvaluate_ShadowRun5Glitch61Exploding1() throws ParserException {
-    int[] rolls = {6,1,1}; 
+    int[] rolls = {6, 1, 1};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr5e");
     assertEquals("Hits: 1 Ones: 2 *Glitch*  Results: 6 1 1 ", result.getValue());
   }
+
   public void testEvaluate_ShadowRun5Glitch66Exploding6611() throws ParserException {
-    int[] rolls = {6,6,6,6,1,1};
+    int[] rolls = {6, 6, 6, 6, 1, 1};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2sr5e");
     // this is still a glitch.
     assertEquals("Hits: 4 Ones: 2 *Glitch*  Results: 6 6 6 6 1 1 ", result.getValue());
   }
 
-
-
-
-
   public void testEvaluate_ExplodeWithMockRunData() throws ParserException {
-    int[] rolls = {3, 6, 6, 2}; 
+    int[] rolls = {3, 6, 6, 2};
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2d6e");
     assertEquals(new BigDecimal(17), result.getValue());

--- a/src/test/java/net/rptools/common/expression/ExpressionParserWithMockRollsTest.java
+++ b/src/test/java/net/rptools/common/expression/ExpressionParserWithMockRollsTest.java
@@ -134,7 +134,7 @@ public class ExpressionParserWithMockRollsTest extends TestCase {
   }
 
   public void testEvaluate_ExplodeWithMockRunData() throws ParserException {
-    int[] rolls = {3, 6, 6, 2};
+    int[] rolls = {3, 6, 6, 2}; // explode both sixes
     setUpMockRunData(rolls);
     Result result = new ExpressionParser().evaluate("2d6e");
     assertEquals(new BigDecimal(17), result.getValue());


### PR DESCRIPTION
Added Shadowrun 5 Roll
Unit Tests
Signalize Gremlin-Caused Glitches

Difference between SR4 and SR5 roll consists in exactly half the pool not yet causing a glitch in SR5.
There might have been a bug already, with the `times` parameter being modified after being passed, where the SR5 implementation requires the original, not the modified value. Someone with access to SR4 rulebooks might want to check if the behaviour was intended in SR4 and has changed, or if it (still) is a bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/dicelib/61)
<!-- Reviewable:end -->
