### PR TITLE
Update grigit in build as jcenter is not available for this older version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,12 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
 // Access Git info from build script
 plugins {
-    id "org.ajoberstar.grgit" version "4.1.0"
+    id "org.ajoberstar.grgit" version "4.1.1"
     id "com.diffplug.spotless" version "5.0.0"
 }
 


### PR DESCRIPTION
Update grigit in build as jcenter is not available for this older version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rptools/dicelib/145)
<!-- Reviewable:end -->
